### PR TITLE
GHC-42: Configuring ALE as the default identifier source

### DIFF
--- a/configuration/openmrs/apps/registration/app.json
+++ b/configuration/openmrs/apps/registration/app.json
@@ -35,7 +35,7 @@
             },
 
             "autoCompleteFields":["familyName", "caste"],
-            "defaultIdentifierPrefix": "VV",
+            "defaultIdentifierPrefix": "ALE",
             "defaultVisitType": "OPD",
             "searchByIdForwardUrl": "/patient/{{patientUuid}}",
             "showMiddleName": true,


### PR DESCRIPTION
See Krzysztof Garbarz comment on GHC-42. We wat the following identifier prefixes in the drop-down: ALE, AME, BOM, CUB, OLI, SOC, INO, BAL, CER, LAU.

I just made the first one (ALE) the default.